### PR TITLE
If version is not specified in the manifest, get it from setup.py

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,3 +1,2 @@
-version: 0.7.0
 name: ship_it
 

--- a/ship_it/__init__.py
+++ b/ship_it/__init__.py
@@ -5,10 +5,16 @@ from os import path
 from ship_it.manifest import Manifest, get_manifest_from_path
 from ship_it import cli
 from ship_it.virtualenv import VirtualEnvPackager
+import subprocess
+import sys
 
 
 def validate_path(path_to_check):
     assert path.isabs(path_to_check) and path.isfile(path_to_check)
+
+def version_from_setup_py(setup_py_path):
+    out = subprocess.check_output([sys.executable, setup_py_path, '--version'])
+    return out.decode('utf-8').rstrip()
 
 
 def fpm(manifest_path, requirements_file_path=None, setup_py_path=None,
@@ -30,6 +36,10 @@ def fpm(manifest_path, requirements_file_path=None, setup_py_path=None,
 
     man_args, man_flags = manifest.get_args_and_flags()
     man_flags.extend(overrides.items())
+
+    if not any(flag[0] == 'version' for flag in man_flags):
+        man_flags.extend([('version', version_from_setup_py(setup_py_path))])
+
     command_line = cli.get_command_line(man_args, man_flags)
 
     cli.invoke_fpm(command_line)

--- a/tests/test_full_invocation.py
+++ b/tests/test_full_invocation.py
@@ -13,7 +13,7 @@ import ship_it
 @mock.patch('ship_it.validate_path')
 @mock.patch('ship_it.cli.invoke_fpm')
 @mock.patch('ship_it.Manifest.get_args_and_flags',
-            return_value=(['arg'], [('--flag', 'value')]))
+            return_value=(['arg'], [('version', '1.2.3')]))
 @mock.patch('ship_it.cli.get_command_line', return_value='command line')
 def test_manifest_calls(mock_cl, mock_get, mock_invoke, mock_val,
                         mock_pack, mock_patch, manifest):
@@ -29,7 +29,7 @@ def test_manifest_calls(mock_cl, mock_get, mock_invoke, mock_val,
 
     assert all(mocked.called for mocked in mocked_functions)
     assert mock_val.mock_calls == [mock.call('/test_dir/manifest.yaml')]
-    mock_cl.assert_called_once_with(['arg'], [('--flag', 'value'),
+    mock_cl.assert_called_once_with(['arg'], [('version', '1.2.3'),
                                               ('overridden', 'flag')])
     mock_invoke.assert_called_once_with('command line')
 


### PR DESCRIPTION
And use this new feature for ship_it itself.

This removes the duplication of version number between manifest.yaml
and setup.py, and also allows use of a tool like Versioneer
(https://pypi.python.org/pypi/versioneer/).

Adjust a test to have a version number to avoid trying to call setup.py.

@herrewig OK with you?